### PR TITLE
Pin pnpm action to SHA

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: '22'
       -
         name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
         with:
           version: '10'
       -


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pr-checks.yml` file. The change updates the `pnpm/action-setup` GitHub Action to a specific commit hash for more precise version control.

* [`.github/workflows/pr-checks.yml`](diffhunk://#diff-1da7a27709d11ac16eef3de8e46ed10672b7b1d63a790ffbcbd23a94b19efdcbL26-R26): Changed `pnpm/action-setup` from version `v4` to commit `a7487c7e89a18df4991f7f222e4898a00d66ddda`.