### PR TITLE
Fix code scanning alert - Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,6 +13,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       -
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #5

Add necessary permissions to the workflow in `.github/workflows/pr-checks.yml` to fix the code scanning alert.

* Add a `permissions` key under the `jobs` section.
* Set `contents: read` for the `actions/checkout@v4` step.
* Set `packages: read` for the `pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Socio-Development/monospace/pull/6?shareId=d58a1f6e-7635-491a-bf8f-5fac31e6a11d).